### PR TITLE
Fix: Collections Endpoint

### DIFF
--- a/openeo_fastapi/client/collections.py
+++ b/openeo_fastapi/client/collections.py
@@ -3,12 +3,17 @@
 Classes:
     - CollectionRegister: Framework for defining and extending the logic for working with Collections.
 """
+import logging
+
 import aiohttp
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from openeo_fastapi.api.models import Collection, Collections
 from openeo_fastapi.api.types import Endpoint, Error
 from openeo_fastapi.client.register import EndpointRegister
+
+logger = logging.getLogger(__name__)
 
 COLLECTIONS_ENDPOINTS = [
     Endpoint(
@@ -111,22 +116,29 @@ class CollectionRegister(EndpointRegister):
         path = "collections"
         resp = await self._proxy_request(path)
 
-        if resp:
-            collections_list = [
-                collection
-                for collection in resp["collections"]
-                if (
-                    not self.settings.STAC_COLLECTIONS_WHITELIST
-                    or collection["id"] in self.settings.STAC_COLLECTIONS_WHITELIST
-                )
-            ]
-
-            return Collections(collections=collections_list, links=resp["links"])
-        else:
+        if not resp:
             raise HTTPException(
                 status_code=404,
                 detail=Error(code="NotFound", message="No Collections found."),
             )
+
+        valid_collections = []
+        for collection in resp["collections"]:
+            if (
+                self.settings.STAC_COLLECTIONS_WHITELIST
+                and collection.get("id") not in self.settings.STAC_COLLECTIONS_WHITELIST
+            ):
+                continue
+            try:
+                valid_collections.append(Collection(**collection))
+            except (ValidationError, Exception) as e:
+                logger.warning(
+                    "Dropping collection %r from response due to validation error: %s",
+                    collection.get("id"),
+                    e,
+                )
+
+        return Collections(collections=valid_collections, links=resp["links"])
 
     async def get_collection_items(self, collection_id):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openeo-fastapi"
-version = "2026.5.2"
+version = "2026.5.3"
 description = "FastApi implementation conforming to the OpenEO Api specification."
 authors = ["Sean Hoyal <sean.hoyal@external.eodc.eu>"]
 readme = "README.md"

--- a/tests/api/test_collections.py
+++ b/tests/api/test_collections.py
@@ -15,7 +15,7 @@ async def test_get_collections(collections_core, collections):
 
         data = await collections_core.get_collections()
 
-        assert data == collections
+        assert data["collections"] == [Collection(**c) for c in collections["collections"]]
         m.assert_called_once_with(get_collections_url)
 
 
@@ -36,7 +36,7 @@ async def test_get_collections_whitelist(collections_core, collections, s2a_coll
 
             col = data["collections"][0]
 
-            assert col == s2a_collection
+            assert col == Collection(**s2a_collection)
             m.assert_called_once_with(get_collections_url)
 
 


### PR DESCRIPTION
Fix: drop collections from response gracefully and log any validation-errors instead of crashing the endpoint